### PR TITLE
Removing inclusive and exclusive functionality for between

### DIFF
--- a/src/Particle/Validator/Chain.php
+++ b/src/Particle/Validator/Chain.php
@@ -96,16 +96,15 @@ class Chain
     }
 
     /**
-     * Validate that the value is between $min and $max (inclusive by default).
+     * Validate that the value is between $min and $max (inclusive).
      *
      * @param int $min
      * @param int $max
-     * @param bool $inclusive
      * @return $this
      */
-    public function between($min, $max, $inclusive = true)
+    public function between($min, $max)
     {
-        return $this->addRule(new Rule\Between($min, $max, $inclusive));
+        return $this->addRule(new Rule\Between($min, $max));
     }
 
     /**

--- a/src/Particle/Validator/Rule/Between.php
+++ b/src/Particle/Validator/Rule/Between.php
@@ -33,8 +33,8 @@ class Between extends Rule
      * @var array
      */
     protected $messageTemplates = [
-        self::TOO_BIG => '{{ name }} is too big, upper limit is {{ max }}',
-        self::TOO_SMALL => '{{ name }} is too small, lower limit is {{ min }}',
+        self::TOO_BIG => '{{ name }} must be less than {{ max }}',
+        self::TOO_SMALL => '{{ name }} must be greater than {{ min }}',
     ];
 
     /**
@@ -52,22 +52,15 @@ class Between extends Rule
     protected $max;
 
     /**
-     * @var bool
-     */
-    protected $inclusive;
-
-    /**
      * Construct the Between rule.
      *
      * @param int $min
      * @param int $max
-     * @param bool $inclusive
      */
-    public function __construct($min, $max, $inclusive = true)
+    public function __construct($min, $max)
     {
         $this->min = $min;
         $this->max = $max;
-        $this->inclusive = (bool) $inclusive;
     }
 
     /**
@@ -78,18 +71,10 @@ class Between extends Rule
      */
     public function validate($value)
     {
-        $min = $this->min;
-        $max = $this->max;
-
-        // inclusive
-        if (!$this->inclusive) {
-            $min++;
-            $max--;
-        }
-        if ($value < $min) {
+        if ($value < $this->min) {
             return $this->error(self::TOO_SMALL);
         }
-        if ($value > $max) {
+        if ($value > $this->max) {
             return $this->error(self::TOO_BIG);
         }
         return true;

--- a/src/Particle/Validator/Rule/Between.php
+++ b/src/Particle/Validator/Rule/Between.php
@@ -33,8 +33,8 @@ class Between extends Rule
      * @var array
      */
     protected $messageTemplates = [
-        self::TOO_BIG => '{{ name }} must be less than {{ max }}',
-        self::TOO_SMALL => '{{ name }} must be greater than {{ min }}',
+        self::TOO_BIG => '{{ name }} must be less than or equal to {{ max }}',
+        self::TOO_SMALL => '{{ name }} must be greater than or equal to {{ min }}',
     ];
 
     /**

--- a/tests/Particle/Validator/Rule/BetweenTest.php
+++ b/tests/Particle/Validator/Rule/BetweenTest.php
@@ -34,40 +34,6 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([], $this->validator->getMessages());
     }
 
-    public function testValidatesExclusiveOnRequestLowerLimit()
-    {
-        $this->validator->required('number')->between(1, 10, false);
-        $result = $this->validator->validate(['number' => 1]);
-
-        $expected = [
-            'number' => [
-                Between::TOO_SMALL => $this->getMessage(Between::TOO_SMALL)
-            ]
-        ];
-        $this->assertFalse($result);
-        $this->assertEquals($expected, $this->validator->getMessages());
-
-        $this->assertTrue($this->validator->validate(['number' => 2]));
-        $this->assertFalse($this->validator->validate(['number' => 10]));
-    }
-
-    public function testValidatesExclusiveOnRequestUpperLimit()
-    {
-        $this->validator->required('number')->between(1, 10, false);
-        $result = $this->validator->validate(['number' => 10]);
-
-        $expected = [
-            'number' => [
-                Between::TOO_BIG => $this->getMessage(Between::TOO_BIG)
-            ]
-        ];
-        $this->assertFalse($result);
-        $this->assertEquals($expected, $this->validator->getMessages());
-
-        $this->assertTrue($this->validator->validate(['number' => 2]));
-        $this->assertFalse($this->validator->validate(['number' => 10]));
-    }
-
     public function testReturnsFalseForValuesNotBetweenMinAndMaxLowerError()
     {
         $this->validator->required('number')->between(1, 10);
@@ -99,8 +65,8 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
     public function getMessage($reason)
     {
         $messages = [
-            Between::TOO_SMALL => 'number is too small, lower limit is 1',
-            Between::TOO_BIG => 'number is too big, upper limit is 10',
+            Between::TOO_SMALL => 'number must be greater than 1',
+            Between::TOO_BIG => 'number must be less than 10',
         ];
 
         return $messages[$reason];

--- a/tests/Particle/Validator/Rule/BetweenTest.php
+++ b/tests/Particle/Validator/Rule/BetweenTest.php
@@ -65,8 +65,8 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
     public function getMessage($reason)
     {
         $messages = [
-            Between::TOO_SMALL => 'number must be greater than 1',
-            Between::TOO_BIG => 'number must be less than 10',
+            Between::TOO_SMALL => 'number must be greater than or equal to 1',
+            Between::TOO_BIG => 'number must be less than or equal to 10',
         ];
 
         return $messages[$reason];


### PR DESCRIPTION
Removed inclusive/exclusive bool from the Between rule, as it makes more sense adjusting the boundaries than using a bool to do so. Also, I've adjusted the error messages to reflect the standard we've recently introduced ("x must be y" rather than "something is wrong with x" or "it is not y").
